### PR TITLE
fix: handle --clean flag in argument parsing

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,6 +27,10 @@ for OPT in "$@" ; do
             case $OPT in
                --help)
                     show_usage;;
+                --clean)
+                    clean
+                    echo "Config files removed."
+                    exit 0 ;;
                 --name=*)
                     NAME=${OPT##*=}
                     shift ;;


### PR DESCRIPTION
## Summary

The `--clean` flag was documented in `show_usage()` and the `clean()` function existed, but the argument parsing loop had no `case` branch for it. As a result, `./build.sh --clean` silently did nothing.

## Changes

- Added `--clean)` case to the argument parsing loop in `build.sh`
- Calls the existing `clean()` function and exits with code 0

## Testing

The fix is minimal — it wires the existing `clean()` function to the documented flag. Manual verification: `./build.sh --clean` now correctly removes the config files as documented.

Fixes tarmolov/configs#3