### PR TITLE
fix: migrate git-vommit from Python 2 to Python 3

### DIFF
--- a/.bin/git-vommit
+++ b/.bin/git-vommit
@@ -1,10 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, os
-import urllib2
+from urllib.request import urlopen
 
 def msg():
-    return urllib2.urlopen('http://whatthecommit.com/index.txt').read().strip()
+    return urlopen('http://whatthecommit.com/index.txt').read().decode().strip()
 
 if __name__ == '__main__':
     do_it = sys.stdout.write if '--wimp' in sys.argv else os.system


### PR DESCRIPTION
## Summary

`urllib2` was removed in Python 3. The script failed with `ModuleNotFoundError` on any modern system.

## Changes

- Changed shebang to `python3`
- Replaced `import urllib2` with `from urllib.request import urlopen`
- Added `.decode()` to convert response bytes to string

## Testing

Python 3 syntax verified. The logic is identical — only the import path changed.

Fixes tarmolov/configs#5