### PR TITLE
fix: ..... alias should go up 4 levels, not 3

### DIFF
--- a/.bash/aliases.common.bash
+++ b/.bash/aliases.common.bash
@@ -32,7 +32,7 @@ alias l.='ls -d .* --color=auto'
 alias ..='cd ..'
 alias ...='cd ../../'
 alias ....='cd ../../../'
-alias .....='cd ../../../'
+alias .....='cd ../../../../'
 
 alias wget='wget -c' # resume by default
 alias df='df -H'


### PR DESCRIPTION
## Summary

The `.....` alias (5 dots) was identical to `....` (4 dots) — both went up 3 levels. By the naming convention, N dots should go up N-1 levels.

## Changes

- `.bash/aliases.common.bash`: changed `.....` from `cd ../../../` to `cd ../../../../`

## Testing

One-liner change, no side effects.

Fixes tarmolov/configs#6