### PR TITLE
fix: add missing Syntastic plugin declaration in .vimrc

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -18,6 +18,7 @@ Plugin 'Marks-Browser'
 Plugin 'matchit.zip'
 Plugin 'scrooloose/nerdcommenter'
 Plugin 'scrooloose/nerdtree'
+Plugin 'scrooloose/syntastic'
 Plugin 'vim-scripts/LargeFile'
 Plugin 'ervandew/supertab'
 


### PR DESCRIPTION
## Summary

Added the missing `scrooloose/syntastic` plugin declaration to the Vundle bundle list.

## Changes

- `.vimrc`: added `Plugin 'scrooloose/syntastic'` alongside other scrooloose plugins

Fixes #9