### PR TITLE
fix: update Vundle plugin path to canonical VundleVim/Vundle.vim

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -9,7 +9,7 @@ set rtp+=~/.vim/bundle/Vundle.vim
 call vundle#begin()
 
 " Bundles
-Plugin 'gmarik/vundle'
+Plugin 'VundleVim/Vundle.vim'
 Plugin 'bkad/CamelCaseMotion'
 Plugin 'gcmt/taboo.vim'
 Plugin 'jistr/vim-nerdtree-tabs'


### PR DESCRIPTION
## Summary

Updates the Vundle self-declaration to use the canonical repository path.

## Changes

- `.vimrc`: changed `Plugin 'gmarik/vundle'` → `Plugin 'VundleVim/Vundle.vim'` to match what `build.sh` actually clones

Fixes #10