### PR TITLE
fix: replace deprecated :BundleInstall with :PluginInstall in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -64,7 +64,7 @@ echo "Install vim plugins..."
 cd ~/.config/tarmolov
 git clone https://github.com/VundleVim/Vundle.vim.git ~/.vim/bundle/Vundle.vim
 sleep 1
-vim -c ":BundleInstall" -c ":qa"
+vim -c ":PluginInstall" -c ":qa"
 cd - >> /dev/null
 
 echo "Generate .profile and .gitconfig"


### PR DESCRIPTION
## Summary

Replaces the deprecated Vundle API call with the modern one.

## Changes

- `build.sh`: changed `vim -c ":BundleInstall"` → `vim -c ":PluginInstall"`

Fixes #11