### PR TITLE
fix: remove unused vcs_info setup from .zshrc

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -5,13 +5,6 @@
 . ~/.config/tarmolov/.bash/z.sh
 . ~/.config/tarmolov/.bash/arc-prompt.bash
 
-# Load version control information
-autoload -Uz vcs_info
-precmd() { vcs_info }
-
-# Format the vcs_info_msg_0_ variable
-zstyle ':vcs_info:git:*' formats 'on %b'
-
 setopt PROMPT_SUBST
 export PROMPT='%F{green}%n@%m%f %~%F{green}$(__git_ps1 " (%s)")%f $ '
 


### PR DESCRIPTION
## Summary

Removes the dead `vcs_info` block that ran on every prompt but whose output was never used.

## Changes

- `.zshrc`: removed `autoload -Uz vcs_info`, `precmd() { vcs_info }`, and `zstyle` config — the prompt already uses `$(__git_ps1)` from `git-prompt.bash` directly

Fixes #12