### PR TITLE
fix: apply fixes from issue #29

### DIFF
--- a/.bash/aliases.common.bash
+++ b/.bash/aliases.common.bash
@@ -3,7 +3,7 @@ alias bc='bc -l' # start calculator with math support
 alias cmpf="complete -F"
 alias screen='screen -T linux -s /bin/bash'
 alias mkdir='mkdir -pv' # create parent directories on demand
-alias diff='colordiff'
+command -v colordiff &>/dev/null && alias diff='colordiff'
 alias path='echo -e ${PATH//:/\\n}'
 
 # svn
@@ -11,8 +11,8 @@ alias surl='svn info | grep URL'
 alias svst='svn st --ignore-externals | grep -v ^X'
 
 # debian
-alias dch='dch --distributor debian'
-alias debrelease='if [ -e dupload.conf ]; then debrelease -c --nomail; else debrelease --nomail; fi'
+command -v dch &>/dev/null && alias dch='dch --distributor debian'
+command -v debrelease &>/dev/null && alias debrelease='if [ -e dupload.conf ]; then debrelease -c --nomail; else debrelease --nomail; fi'
 
 # editor
 alias vi=vim
@@ -39,8 +39,8 @@ alias df='df -H'
 alias du='du -ch'
 alias ducks="du -cks * | sort -rn | head -n11"
 
-sdiff() {
-    svn diff --no-diff-deleted $@ | colordiff | less -SR
+svndiff() {
+    svn diff --no-diff-deleted "$@" | colordiff | less -SR
 }
 
 # Set appropriate ls alias

--- a/.bash/aliases.git.bash
+++ b/.bash/aliases.git.bash
@@ -18,4 +18,4 @@ alias gco="git checkout"
 alias gcp="git cherry-pick"
 alias glg="git lg"
 alias ghist="git hist"
-alias gr='cd "`git rev-parse --show-toplevel`"'
+alias gr='cd "$(git rev-parse --show-toplevel)"'

--- a/.bashrc
+++ b/.bashrc
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-if [ -f ~/.bashrc ] && [ ! -L ~/.bashrc ]; then
-   . ~/.bashrc
-fi
-
 . ~/.config/tarmolov/.bash/git-completion.bash
 . ~/.config/tarmolov/.bash/git-prompt.bash
 . ~/.config/tarmolov/.bash/git-flow-completion.bash

--- a/.git-aliases/common
+++ b/.git-aliases/common
@@ -14,7 +14,6 @@
     lost = !"git fsck | awk '/dangling commit/ {print $3}' | xargs git show --format='SHA1: %C(yellow)%h%Creset %f' | awk '/SHA1/ {sub(\"SHA1: \", \"\"); print}'"
     in = !"git remote update -p > /dev/null 2>&1; git hist ..@{u}"
     out = !"git hist @{u}.."
-    ppush = !"git sh @{u}.."
     snapshot = !git stash push -m "snapshot: $(date)" && git stash apply "stash@{0}"
     ours   = "!f() { git checkout --ours $@ && git add $@; }; f"
     theirs = "!f() { git checkout --theirs $@ && git add $@; }; f"

--- a/.gitconfig
+++ b/.gitconfig
@@ -25,10 +25,10 @@
     whitespace = space-before-tab,trailing-space
     excludesfile = ~/.gitignore
 [push]
-    default = upstream
+    default = simple
     followTags = true
 [gc]
-    auto = 0
+    auto = 500
 [branch]
     autosetuprebase = always
 [merge]

--- a/.vimrc
+++ b/.vimrc
@@ -50,17 +50,24 @@ let g:SuperTabDefaultCompletionType = '<c-x><c-o>'
 " ALE settings
 let g:ale_sign_error = "✗"
 let g:ale_sign_warning = "⚠"
-let g:ale_fix_on_save = 0
+let g:ale_fixers = {
+\   '*': ['remove_trailing_lines', 'trim_whitespace'],
+\}
+let g:ale_fix_on_save = 1
 
 " Common
 syntax on
-filetype plugin on
 set omnifunc=syntaxcomplete#Complete
 
 set langmenu=none                   " use english menu
 set hidden                          " don't unload buffer before switching
 set autoread                        " autoread changing of file
-set spelllang=ru_ru,en_us           " spellchecker for english and russian
+" spellchecker — Russian only if spell file is available
+if filereadable(globpath(&rtp, 'spell/ru.utf-8.spl', 1))
+    set spelllang=ru,en_us
+else
+    set spelllang=en_us
+endif
 set history=150                     " size of history
 set undolevels=1000                 " max count of undo commands
 set nobackup                        " don't make backup
@@ -112,6 +119,11 @@ set list listchars=tab:▸\ ,trail:·,extends:→,precedes:←,nbsp:×
 set background=dark
 silent! colorscheme solarized8
 
+" Define statusline highlight groups
+hi User1 ctermfg=white  ctermbg=238 guifg=#ffffff guibg=#444444
+hi User2 ctermfg=yellow ctermbg=238 guifg=#ffff00 guibg=#444444
+hi User3 ctermfg=cyan   ctermbg=238 guifg=#00ffff guibg=#444444
+
 " Command line
 set wildmenu                        " show autocompleate words
 set showmatch                       " show matched paranthes
@@ -146,13 +158,8 @@ set sessionoptions+=unix,slash      " comfortable movement files from unix to wi
 vmap < <gv
 vmap > >gv
 
-" remap for CamelCaseMotion
-map <silent> w <Plug>CamelCaseMotion_w
-map <silent> b <Plug>CamelCaseMotion_b
-map <silent> e <Plug>CamelCaseMotion_e
-sunmap w
-sunmap b
-sunmap e
+" CamelCaseMotion via leader prefix (preserves dw/cw/yw operator-pending)
+let g:camelcasemotion_key = '<leader>'
 
 " gf opens file in new tab
 map <silent> gf <C-W>gf:tabm 999<cr>

--- a/build.sh
+++ b/build.sh
@@ -87,27 +87,14 @@ do
     ln -sf ~/.config/tarmolov/$file ~/$file
 done
 # .vim is a directory; create it if needed and link bundle inside
-echo "Set link to .vim/bundle"
-mkdir -p ~/.config/tarmolov/.vim/bundle
-mkdir -p ~/.vim
-ln -sfn ~/.config/tarmolov/.vim/bundle ~/.vim/bundle
-
 echo "Set up .bashrc (wrapper sourcing tarmolov config)"
 grep -qF ". ~/.config/tarmolov/.bashrc" ~/.bashrc 2>/dev/null || echo ". ~/.config/tarmolov/.bashrc" >> ~/.bashrc
 
 echo "Set up .zshrc (wrapper sourcing tarmolov config)"
 grep -qF ". ~/.config/tarmolov/.zshrc" ~/.zshrc 2>/dev/null || echo ". ~/.config/tarmolov/.zshrc" >> ~/.zshrc
 
-echo "Install vim plugins..."
-cd ~/.config/tarmolov
-if [ ! -d ~/.vim/bundle/Vundle.vim ]; then
-    git clone https://github.com/VundleVim/Vundle.vim.git ~/.vim/bundle/Vundle.vim
-else
-    echo "Vundle already installed, skipping clone."
-fi
-sleep 1
-vim -c ":PluginInstall" -c ":qa"
-cd - > /dev/null 2>&1
+echo "Installing vim plugins..."
+vim -c ":PlugInstall" -c ":qa"
 
 echo "Generate .profile and .gitconfig"
 

--- a/update.sh
+++ b/update.sh
@@ -8,6 +8,6 @@ echo "Pulling latest changes..."
 git pull
 
 echo "Updating vim plugins..."
-vim -c ":PluginUpdate" -c ":qa"
+vim -c ":PlugUpdate" -c ":qa"
 
 echo "Update complete."


### PR DESCRIPTION
Closes #29

## Changes

### 🔴 Critical fixes
- **build.sh**: remove Vundle clone/install, use `:PlugInstall` (vim-plug)
- **update.sh**: fix `:PluginUpdate` → `:PlugUpdate`
- **.vimrc**: define `User1`/`User2`/`User3` highlight groups for statusline

### 🟡 Bug fixes
- **.vimrc**: remove duplicate `filetype plugin on` declaration
- **.vimrc**: fix CamelCaseMotion — use `g:camelcasemotion_key` to preserve `dw`/`cw`/`yw`
- **.vimrc**: guard `spelllang` Russian locale against missing spell files
- **.bash/aliases.common.bash**: guard `colordiff` alias behind availability check
- **.bash/aliases.common.bash**: rename `sdiff()` → `svndiff()` (was shadowing system command)
- **.bash/aliases.common.bash**: guard Debian aliases (`dch`, `debrelease`) conditionally
- **.bashrc**: remove broken self-referential `.bashrc` guard
- **.bash/aliases.git.bash**: fix `gr` alias — replace backticks with `$()`
- **.gitconfig**: `push.default` upstream → simple
- **.gitconfig**: `gc.auto` 0 → 500
- **.git-aliases/common**: remove dead `ppush` alias

### 🔵 Nice-to-have
- **.vimrc**: add ALE fixers (`remove_trailing_lines`, `trim_whitespace`) with `fix_on_save = 1`