### PR TITLE
fix: second-pass improvements — vim, shell, zsh, git

### DIFF
--- a/.bash/aliases.common.bash
+++ b/.bash/aliases.common.bash
@@ -16,12 +16,11 @@ command -v debrelease &>/dev/null && alias debrelease='if [ -e dupload.conf ]; t
 
 # editor
 alias vi=vim
-alias vim='vim -p'
 alias svim='sudoedit'
 alias e='vim'
 
 # grep
-alias rgrep='grep -r --exclude=.git --exclude=\*.svn\*'
+alias rgrep='grep -r --exclude-dir=.git --exclude-dir=.svn --exclude-dir=node_modules --exclude-dir=__pycache__ --exclude-dir=dist --exclude-dir=build'
 alias less='less -FRX'
 
 # ls

--- a/.bash/env.bash
+++ b/.bash/env.bash
@@ -1,0 +1,18 @@
+# Shared environment variables — sourced by both .bashrc and .zshrc
+
+export TERM=xterm-256color
+export LESSCHARSET=utf-8
+export EDITOR=vim
+export GIT_PS1_SHOWDIRTYSTATE=1
+export ACK_PAGER='less -FRX'
+
+# PATH
+export PATH=/usr/local/bin:/usr/local/sbin:$PATH
+[ -d ~/bin ] && PATH=~/bin:/usr/local/share/npm/bin:"${PATH}"
+
+# Locale + Apple Silicon Homebrew
+case $(uname) in
+    Linux) export LC_ALL="en_US.utf8" ;;
+    *)     export LC_ALL="en_US.UTF-8"
+           [ -d /opt/homebrew/bin ] && export PATH="/opt/homebrew/bin:$PATH" ;;
+esac

--- a/.bashrc
+++ b/.bashrc
@@ -9,28 +9,9 @@
 . ~/.config/tarmolov/.bash/z.sh
 . ~/.config/tarmolov/.bash/arc-prompt.bash
 
-export TERM=xterm-256color
-export LESSCHARSET=utf-8
-export EDITOR=vim
-export GIT_PS1_SHOWDIRTYSTATE=1
 export PS1='\[\e[0;32m\]\u@\h\[\e[m\] \[\e[1;34m\]\w\[\e[m\]\[\e[1;32m\]$(__arc_ps1)$(__git_ps1 " (%s)") \$\[\e[m\] \[\e[1;37m\]'
-export ACK_PAGER='less -FRX'
 
-# locale
-OS=$(uname)
-if [ "$OS" = "Linux" ]; then
-    export LC_ALL="en_US.utf8"
-else
-    export LC_ALL="en_US.UTF-8"
-    # Apple Silicon Homebrew
-    [ -d /opt/homebrew/bin ] && export PATH="/opt/homebrew/bin:$PATH"
-fi
-
-# Use local bin before
-export PATH=/usr/local/bin:/usr/local/sbin:$PATH
-if [ -d ~/bin ] ; then
-    PATH=~/bin:/usr/local/share/npm/bin:"${PATH}"
-fi
+. ~/.config/tarmolov/.bash/env.bash
 
 # Load local overrides if present
 [ -f ~/.bash/local.bash ] && source ~/.bash/local.bash

--- a/.gitconfig
+++ b/.gitconfig
@@ -40,7 +40,10 @@
 [advice]
     statushints = false
 [diff]
-    algorithm = patience
+    algorithm = histogram
+[rerere]
+    enabled = true
+    autoupdate = true
 [pull]
     rebase = true
 [fetch]

--- a/.vimrc
+++ b/.vimrc
@@ -21,9 +21,6 @@ Plug 'ervandew/supertab'
 
 Plug 'lifepillar/vim-solarized8'
 Plug 'editorconfig/editorconfig-vim'
-Plug 'ekalinin/Dockerfile.vim'
-Plug 'ingydotnet/yaml-vim'
-Plug 'leafgarland/typescript-vim'
 Plug 'MaxMEllon/vim-jsx-pretty'
 Plug 'fatih/vim-go'
 Plug 'sheerun/vim-polyglot'
@@ -70,6 +67,11 @@ else
 endif
 set history=150                     " size of history
 set undolevels=1000                 " max count of undo commands
+if has('persistent_undo')
+    let &undodir = expand('~/.vim/undodir')
+    silent! call mkdir(&undodir, 'p')
+    set undofile
+endif
 set nobackup                        " don't make backup
 set nowb
 " NOTE: swapfile is enabled for crash recovery (noswapfile removed)
@@ -102,11 +104,9 @@ augroup MyVimrc
   autocmd QuickFixCmdPost    l* nested lwindow
   autocmd BufNewFile,BufRead *.wiki set filetype=wiki syntax=wp
   au BufNewFile,BufRead *.yaml,*.yml setf yaml
-  " Delete spaces from end of lines (skip markdown and diff to preserve two-space line breaks)
-  autocmd BufWritePre * if &filetype !~# 'markdown\|diff' | :%s/\s\+$//e | endif
-  autocmd BufWritePre * silent! :%s#\($\n\s*\)\+\%$## " Delete trailing lines at the end of file
   autocmd FocusLost * silent! wa      " Auto save files when focus is lost
-  autocmd BufLeave * silent! :w       "   or leave buffer
+  autocmd FocusGained,BufEnter,CursorHold,CursorHoldI *
+      \ if mode() !~ '\v(c|r.?|!|t)' && getcmdwintype() == '' | checktime | endif
 augroup END
 set pastetoggle=<Leader>p           " Invert paste mod
 

--- a/.zshrc
+++ b/.zshrc
@@ -2,16 +2,10 @@
 HISTFILE=~/.zsh_history
 HISTSIZE=10000
 SAVEHIST=10000
-setopt APPEND_HISTORY SHARE_HISTORY HIST_IGNORE_DUPS
+setopt APPEND_HISTORY SHARE_HISTORY HIST_IGNORE_ALL_DUPS HIST_IGNORE_SPACE HIST_REDUCE_BLANKS
 
-# Locale
-if [[ $(uname) == "Linux" ]]; then
-    export LC_ALL="en_US.utf8"
-else
-    export LC_ALL="en_US.UTF-8"
-    # Apple Silicon Homebrew
-    [ -d /opt/homebrew/bin ] && export PATH="/opt/homebrew/bin:$PATH"
-fi
+# Zsh completions (must come before bashcompinit)
+autoload -Uz compinit && compinit
 
 # Bash compatibility (needed for complete -F and similar)
 autoload -Uz bashcompinit && bashcompinit
@@ -23,23 +17,10 @@ autoload -Uz bashcompinit && bashcompinit
 . ~/.config/tarmolov/.bash/z.sh
 . ~/.config/tarmolov/.bash/arc-prompt.bash
 
-# Zsh completions
-autoload -Uz compinit && compinit
-
 setopt PROMPT_SUBST
 export PROMPT='%F{green}%n@%m%f %~%F{green}$(__git_ps1 " (%s)")%f $ '
 
-export TERM=xterm-256color
-export LESSCHARSET=utf-8
-export EDITOR=vim
-export GIT_PS1_SHOWDIRTYSTATE=1
-export ACK_PAGER='less -FRX'
-
-# Use local bin before
-export PATH=/usr/local/bin:/usr/local/sbin:$PATH
-if [ -d ~/bin ] ; then
-    PATH=~/bin:/usr/local/share/npm/bin:"${PATH}"
-fi
+. ~/.config/tarmolov/.bash/env.bash
 
 # Load local overrides if present
 [ -f ~/.zsh/local.zsh ] && source ~/.zsh/local.zsh


### PR DESCRIPTION
Closes #31

## Changes

### Vim
- Persistent undo (`set undofile`) with auto-created undodir
- Fix `autoread` — CursorHold trigger so files actually reload
- Remove duplicate trailing whitespace cleanup (BufWritePre) — ALE handles it
- Remove aggressive `BufLeave` auto-save (keep FocusLost only)
- Remove plugins already bundled in vim-polyglot: Dockerfile.vim, yaml-vim, typescript-vim

### Shell
- Remove `alias vim='vim -p'` — breaks pipe usage
- Fix `rgrep`: use `--exclude-dir`, add node_modules, __pycache__, dist, build

### Git
- Enable `rerere` — reuse recorded conflict resolutions
- Switch `diff.algorithm` to `histogram` (strictly better than patience)

### Zsh
- Fix `bashcompinit`/`compinit` order (compinit must come first)
- Better history: HIST_IGNORE_ALL_DUPS, HIST_IGNORE_SPACE, HIST_REDUCE_BLANKS

### Structure
- Extract shared env vars into `.bash/env.bash`, source from both `.bashrc` and `.zshrc`